### PR TITLE
docs: note C# Dev Kit misclassifies osu.Game as a test project (benign)

### DIFF
--- a/doc_md/mainline/CHANGELOG.md
+++ b/doc_md/mainline/CHANGELOG.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-05-30
+
+### 调查与决策：C# Dev Kit 误把 osu.Game 当测试工程（确认良性，接受现状，不改功能）
+
+现象：C# Dev Kit Test Explorer 反复对 `osu.Game.dll` 起 VSTest testhost 并中止发现；切 `osu.Desktop.slnf`、`Developer: Reload Window` 均无效。
+
+根因（实证定位，先后排除两条错误假设）：
+- **不是** `<IsTestProject>` 没设——MSBuild 实测求值确为 `false`，Dev Kit 的 Project System 不采纳该属性。
+- **不是** deps.json 里的 `nunit.framework.dll`——把它从 `osu.Game.deps.json` 移除（`NUnit` 改 `ExcludeAssets=runtime`）后 Dev Kit 照样选中 osu.Game。
+- 真因：Dev Kit 的 Project System 按"**是否引用 NUnit 包**"把工程归类为测试容器。osu.Game 为给 `*.Tests` 提供抽象测试场景基类（`osu.Game/Tests/**` 的 `BeatmapConversionTest` / `DifficultyCalculatorTest` 等）而引用 NUnit，于是被误归（slnf 日志"3 projects added" = BMS.Tests + Mania.Tests + 被误判的 osu.Game）。
+
+为何不修（两条路都不可取）：
+- "让 testhost 不崩"：试过 `CopyLocalLockFileAssemblies`（依赖闭包落 `osu.Game/bin`），它修掉第一道坎 `AutoMapper`，但 Dev Kit 紧接着撞第二道坎 `Microsoft.TestPlatform.CommunicationUtilities`——testhost **平台自身**缺失（osu.Game 不引用 `Microsoft.NET.Test.Sdk`）。要跨过就得把 osu.Game 逐步变成完整测试工程（Test.Sdk + testhost 平台 + 适配器），与"它不是测试工程"自相矛盾且越改越偏离上游——**该尝试已回退**。
+- "阻止选中"：只能移走 NUnit 包引用，需迁出 7 个上游文件，违背少改上游红线。
+- 设置层面：无干净的 Dev Kit/VS Code 开关可单独屏蔽该源（仅能整体关闭 Test Explorer，会连真实工程一起丢）。
+
+**结论：接受良性现状。** 该错误只波及 osu.Game 这个伪测试源，**不阻断真实测试**——同一轮日志里 BMS.Tests（860）与 Mania.Tests（780）经 `NUnit Adapter 4.6.0.0` 正常发现；Test Explorer 内真实用例可正常跑，CLI `dotnet test` 一向不受影响。
+
+- 唯一落库改动：[../../osu.Game/osu.Game.csproj](../../osu.Game/osu.Game.csproj) 在 `<IsTestProject>false</IsTestProject>` 上补注释，说明 Dev Kit 忽略该属性、误判源于 NUnit 包引用、无法从 csproj 干净抑制——避免后人重复排查。**无任何功能/构建产物变化**（`osu.Desktop.slnf -c Debug` 仍 0 错误，BMS 全套仍 860/860，均为基线复核）。
+
 ## 2026-05-29
 
 ### P1-L Phase 2（Step A–C）：BMS 专用滚动位置积分旁路落地（门控默认 OFF）
@@ -92,7 +112,7 @@
 ### P1-K：转谱链后置维护与 Test Explorer 退出标记
 
 - BMS→mania 转谱链一轮无行为变化的维护性收口：STOP-freeze `BeatLength = 6` 提升为 [../../osu.Game.Rulesets.Bms/Beatmaps/BmsBeatmapConverter.cs](../../osu.Game.Rulesets.Bms/Beatmaps/BmsBeatmapConverter.cs) 的公开常量 `StopFreezeBeatLength` 并由 [../../osu.Game.Rulesets.Bms/Beatmaps/BmsToManiaBeatmapConverter.cs](../../osu.Game.Rulesets.Bms/Beatmaps/BmsToManiaBeatmapConverter.cs) 共享，消除两份独立魔法常量；[../../osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs](../../osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs) 的 BMS drawable 工厂反射改为缓存强类型委托；[../../osu.Game/Beatmaps/BmsPersistedMetadataResolver.cs](../../osu.Game/Beatmaps/BmsPersistedMetadataResolver.cs) 的 `conversion_version` 补维护契约注释。
-- [../../osu.Game/osu.Game.csproj](../../osu.Game/osu.Game.csproj) 增加 `<IsTestProject>false</IsTestProject>`：osu.Game 因引用 NUnit（抽象测试场景基类）被 C# Dev Kit 误当测试容器，对其启动 testhost 时缺探测路径解析不到缓存 AutoMapper 而中止发现。退出标记仅影响 IDE 测试发现，不改构建/运行，CLI `dotnet test` 不受影响。
+- [../../osu.Game/osu.Game.csproj](../../osu.Game/osu.Game.csproj) 增加 `<IsTestProject>false</IsTestProject>`：osu.Game 因引用 NUnit（抽象测试场景基类）被 C# Dev Kit 误当测试容器，对其启动 testhost 时缺探测路径解析不到缓存 AutoMapper 而中止发现。退出标记仅影响 IDE 测试发现，不改构建/运行，CLI `dotnet test` 不受影响。**（2026-05-30 订正：实测 C# Dev Kit 不采纳 `IsTestProject`，此标记未能阻止误判；详见 2026-05-30 段——经调查该误判无法从 csproj 干净抑制，确认良性、接受现状。）**
 - 验证：`dotnet build osu.Desktop.slnf -c Release` / `-c Debug` 均 0 错误；Mania 转谱聚焦 Release 14/14、Debug 12/12，`osu.Game.Tests` star/sort 聚焦 13/13 通过。详见 [../subline/P1-K/CHANGELOG.md](../subline/P1-K/CHANGELOG.md)。
 
 ## 2026-05-26

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -5,7 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);NU1903</NoWarn>
     <!-- Ships NUnit-based test-scene base classes but is not itself a test container.
-         Opt out of IDE/VSTest test discovery so editors don't launch a testhost against this library. -->
+         Opt out of IDE/VSTest test discovery so editors don't launch a testhost against this library.
+         NOTE: C# Dev Kit's Project System ignores this property and misclassifies osu.Game as a test project
+         purely because it references the NUnit package; that misclassification cannot be suppressed from the csproj
+         without either making osu.Game a full test project or removing the NUnit reference. See doc_md CHANGELOG 2026-05-30. -->
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Label="Nuget">


### PR DESCRIPTION
Dev Kit's Project System classifies osu.Game as a test container purely because it references the NUnit package (for the abstract test-scene base classes under osu.Game/Tests/**), ignoring <IsTestProject>=false. It then launches a doomed VSTest testhost against osu.Game.dll that aborts discovery (first on AutoMapper, then on the test-platform host itself). The error is benign: the real test projects (BMS.Tests 860, Mania.Tests 780) discover and run fine, and CLI dotnet test is unaffected.

Neither suppression path is acceptable — making osu.Game a full test project, or removing the NUnit reference by moving 7 upstream files — so it is accepted as-is. Only changes are an explanatory comment on <IsTestProject> and a CHANGELOG investigation/decision record. No functional or build-output change.